### PR TITLE
Add xdebug package and set html_errors to On

### DIFF
--- a/chef/cookbooks/php/templates/ubuntu/php.ini.erb
+++ b/chef/cookbooks/php/templates/ubuntu/php.ini.erb
@@ -601,7 +601,7 @@ track_errors = Off
 ; Development Value: On
 ; Production value: Off
 ; http://php.net/html-errors
-html_errors = Off
+html_errors = On
 
 ; If html_errors is set On PHP produces clickable error messages that direct
 ; to a page describing the error or function causing the error in detail.

--- a/chef/cookbooks/vagrant-main/recipes/default.rb
+++ b/chef/cookbooks/vagrant-main/recipes/default.rb
@@ -85,6 +85,20 @@ package "php5-mcrypt" do
   action :install
 end
 
+# Install php-xdebug
+package "php5-xdebug" do
+  action :install
+end
+
+template "#{node['php']['ext_conf_dir']}/xdebug.ini" do
+  source "xdebug.ini.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+  action :create
+  notifies :restart, resources("service[apache2]"), :delayed
+end
+
 # Get eth1 ip
 eth1_ip = node[:network][:interfaces][:eth1][:addresses].select{|key,val| val[:family] == 'inet'}.flatten[0]
 


### PR DESCRIPTION
Webgrind didn't work for me as expected because xdebug wasn't installed / enabled.

This should fix the errors. I'm not sure about setting html_errors = On in the php cookbook, might as well make our own template?
